### PR TITLE
add Symbol.observable compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
+// symbol-observable polyfill from redux https://github.com/reduxjs/redux/blob/master/src/utils/symbol-observable.ts
+// @ts-expect-error "Symbol" maybe undefined on legacy platforms
+const $$observable = /* #__PURE__ */ (() =>
+  (typeof Symbol === 'function' && Symbol.observable) || '@@observable')()
+
 // #region TYPES
 
 interface Subscriber {
@@ -151,6 +156,21 @@ export let act: {
     subscriber()
 
     return un
+  }
+  
+  theAct[$$observable] = {
+    subscribe(observer: unknown) {
+      const unsubscribe = theAct.subscribe((state) => {
+        // @ts-expect-error assume observer is spec-compliant
+        if (observer && observer.next) observer.next(state)
+      })
+        
+      return { unsubscribe }
+    },
+
+    [$$observable]() {
+      return this
+    }
   }
 
   return theAct


### PR DESCRIPTION
more information: https://github.com/tc39/proposal-observable
based on redux 
https://github.com/reduxjs/redux/blob/ece840f7e5030ed460894f97a63196baadd9194b/src/createStore.ts#L331

useful for RxJS interoperability https://github.com/ReactiveX/rxjs/blob/7d3c4ec727dd1962275c6f959060fdf6bdc0c164/src/internal/observable/innerFrom.ts#L49