### PR TITLE
send previous state to subscribers

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -108,4 +108,17 @@ test('redefine act.notify', async () => {
   assert.is(calls, 2)
 })
 
+test('get old state in subscriber', async () => {
+  const a = act(0)
+
+  let lastState;
+  a.subscribe((state, last) => {
+    lastState = last
+  })
+
+  a(1)
+  act.notify()
+  assert.is(lastState, 0)
+})
+
 test.run()

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,12 @@ interface Subscriber {
 /** Base mutable reactive primitive, a leaf of reactive graph */
 export interface ActValue<T = unknown> {
   (newState?: T): T
-  subscribe(cb: (state: T) => void): () => void
+  subscribe(cb: (state: T, last: T) => void): () => void
   _s: Set<Subscriber>
 }
 export interface ActComputed<T = unknown> {
   (): T
-  subscribe(cb: (state: T) => void): () => void
+  subscribe(cb: (state: T, last: T) => void): () => void
   _s: Set<Subscriber>
 }
 
@@ -163,7 +163,10 @@ export var act: {
 
           SUBSCRIBER_VERSION++
 
-          if (theAct() !== lastState) cb((lastState = state))
+          if (theAct() !== lastState) {
+            const _lastState = lastState;
+            cb(lastState = state, _lastState)
+          }
         } finally {
           SUBSCRIBER = null
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ export var act: {
 
   theAct.subscribe = (cb) => {
     var queueVersion = -1
-    var lastState: unknown = {}
+    var lastState: unknown = null
 
     // @ts-expect-error `var` could be more performant than `const`
     var subscriber: Subscriber = () => {


### PR DESCRIPTION
This functionality greatly simplifies the separation of stored data from its processing.