### PR TITLE
Отправка подписчикам предыдущего состояния act`ов

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -108,4 +108,17 @@ test('redefine act.notify', async () => {
   assert.is(calls, 2)
 })
 
+test('get old state in subscriber', async () => {
+  const a = act(0)
+
+  let lastState;
+  a.subscribe((state, last) => {
+    lastState = last
+  })
+
+  a(1)
+  act.notify()
+  assert.is(lastState, 0)
+})
+
 test.run()

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -111,14 +111,19 @@ test('redefine act.notify', async () => {
 test('get old state in subscriber', async () => {
   const a = act(0)
 
-  let lastState;
-  a.subscribe((state, last) => {
-    lastState = last
+  let state, prevState;
+  a.subscribe((_state, _prevState) => {
+    state = _state
+    prevState = _prevState
   })
+
+  assert.is(state, 0)
+  assert.is(prevState, undefined)
 
   a(1)
   act.notify()
-  assert.is(lastState, 0)
+  assert.is(state, 1)
+  assert.is(prevState, 0)
 })
 
 test.run()

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,12 @@ interface Subscriber {
 /** Base mutable reactive primitive, a leaf of reactive graph */
 export interface ActValue<T = unknown> {
   (newState?: T): T
-  subscribe(cb: (state: T, last: T) => void): () => void
+  subscribe(cb: (state: T, prevState?: T) => void): () => void
   _s: Set<Subscriber>
 }
 export interface ActComputed<T = unknown> {
   (): T
-  subscribe(cb: (state: T, last: T) => void): () => void
+  subscribe(cb: (state: T, prevState?: T) => void): () => void
   _s: Set<Subscriber>
 }
 
@@ -150,6 +150,7 @@ export var act: {
   theAct.subscribe = (cb) => {
     var queueVersion = -1
     var lastState: unknown = {}
+    var prevState: unknown
 
     // @ts-expect-error `var` could be more performant than `const`
     var subscriber: Subscriber = () => {
@@ -164,8 +165,8 @@ export var act: {
           SUBSCRIBER_VERSION++
 
           if (theAct() !== lastState) {
-            var _lastState = lastState;
-            cb(lastState = state, _lastState)
+            cb((lastState = state), prevState)
+            prevState = state
           }
         } finally {
           SUBSCRIBER = null

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,12 @@ interface Subscriber {
 /** Base mutable reactive primitive, a leaf of reactive graph */
 export interface ActValue<T = unknown> {
   (newState?: T): T
-  subscribe(cb: (state: T) => void): () => void
+  subscribe(cb: (state: T, last: T) => void): () => void
   _s: Set<Subscriber>
 }
 export interface ActComputed<T = unknown> {
   (): T
-  subscribe(cb: (state: T) => void): () => void
+  subscribe(cb: (state: T, last: T) => void): () => void
   _s: Set<Subscriber>
 }
 
@@ -163,7 +163,10 @@ export var act: {
 
           SUBSCRIBER_VERSION++
 
-          if (theAct() !== lastState) cb((lastState = state))
+          if (theAct() !== lastState) {
+            var _lastState = lastState;
+            cb(lastState = state, _lastState)
+          }
         } finally {
           SUBSCRIBER = null
         }


### PR DESCRIPTION
В некоторых ситуациях может потребоваться запустить сайд-эффекты над старым значением (закрыть соединение, удалить связанные объекты и т.п.). В текущей реализации для этого необходимо делать метод-обёртку, который запустит необходимые сайд-эффекты перед сохранением значения, но бывают ситуации, когда такой вариант излишен или неприменим.

Текущая реализация
```js
const sideEffect = (v) => {}
const someAct = act(1)
const setAct = (v) => {
  sideEffect(someAct())
  someAct(v)
}

// Присвоили значение напрямую, а не через setAct, и сайд-эффект утерян
someAct(2)
```

Предлагаемая реализация
```js
const sideEffect = (v) => {}
const someAct = act(1)
someAct.subscribe((_, prevVal) => sideEffect(prevVal))

// Никаких дополнительных сущностей, присваиваем значение и вся связанныя логика отработает сама
someAct(2)
```